### PR TITLE
Testing proptypes

### DIFF
--- a/Utils/index.js
+++ b/Utils/index.js
@@ -1,4 +1,11 @@
+import checkPropTypes from 'check-prop-types';
+
 export const findByTestAttr = (component, attr) => {
   const wrapper = component.find(`[data-test='${attr}']`);
   return wrapper;
+};
+
+export const checkProps = (component, expectedProps) => {
+  const propsErr = checkPropTypes(component.propTypes, expectedProps, 'props', component.name);
+  return propsErr;
 };

--- a/src/App.js
+++ b/src/App.js
@@ -3,13 +3,21 @@ import Header from './component/header';
 import Headline from './component/headline';
 import './App.scss';
 
+const tempArr = [{
+  fName: 'Joe',
+  lName: 'Bloggs',
+  email: 'joebloggs@gmail.com',
+  age: 24,
+  onlineStatus: true
+}]
+
 class App extends Component {
   render() {
     return (
       <div className="App">
         <Header />
         <div className="main">
-          <Headline header="Posts" desc="Click the button to render"/>
+          <Headline header="Posts" desc="Click the button to render" tempArr={tempArr}/>
         </div>
       </div>
     );

--- a/src/component/headline/headline.spec.js
+++ b/src/component/headline/headline.spec.js
@@ -1,6 +1,7 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Headline from './index';
+import checkPropTypes from 'check-prop-types';
 
 import { findByTestAttr } from './../../../Utils';
 
@@ -10,6 +11,25 @@ const setUp = (props={}) => {
 }
 
 describe('Headline Component', () => {
+  describe('Checkling PropTypes', () => {
+    it('Should not throw a warning', () => {
+      const expectedProps = {
+        header: 'Test Header',
+        desc: 'Test Desc',
+        tempArr: [{
+          fName: 'Test fName',
+          lName: 'Test lName',
+          email: 'test@email.com',
+          age: 23,
+          onlineStatus: false
+        }]
+      }
+
+      const propsErr = checkPropTypes(Headline.propTypes, expectedProps, 'props', Headline.name);
+      expect(propsErr).toBeUndefined();
+    });
+  })
+
   describe('Have props', () => {
     let wrapper;
     beforeEach(() => {

--- a/src/component/headline/headline.spec.js
+++ b/src/component/headline/headline.spec.js
@@ -1,9 +1,8 @@
 import React from 'react';
 import { shallow } from 'enzyme';
 import Headline from './index';
-import checkPropTypes from 'check-prop-types';
 
-import { findByTestAttr } from './../../../Utils';
+import { findByTestAttr, checkProps } from './../../../Utils';
 
 const setUp = (props={}) => {
   const component = shallow(<Headline {...props} />);
@@ -25,7 +24,7 @@ describe('Headline Component', () => {
         }]
       }
 
-      const propsErr = checkPropTypes(Headline.propTypes, expectedProps, 'props', Headline.name);
+      const propsErr = checkProps(Headline, expectedProps);
       expect(propsErr).toBeUndefined();
     });
   })

--- a/src/component/headline/index.js
+++ b/src/component/headline/index.js
@@ -1,4 +1,5 @@
-import React, { Component } from 'react'
+import React, { Component } from 'react';
+import PropTypes from 'prop-types';
 
 class Headline extends Component {
   // eslint-disable-next-line no-useless-constructor
@@ -20,6 +21,18 @@ class Headline extends Component {
       </div>
     );
   }
+}
+
+Headline.propTypes = {
+  header: PropTypes.string,
+  desc: PropTypes.string,
+  tempArr: PropTypes.arrayOf(PropTypes.shape({
+    fName: PropTypes.string,
+    lName: PropTypes.string,
+    email: PropTypes.string,
+    age: PropTypes.number,
+    onlineStatus: PropTypes.bool
+  }))
 }
 
 export default Headline;


### PR DESCRIPTION
### How to test proptypes
PropTypes are used to validate props crossing a component. This PR teaches how to test that your proptype are working just fine into your component